### PR TITLE
parsing_texture_color

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ CC = gcc
 SRCS = ./srcs/main.c  \
 		./srcs/parsing/parsing.c \
 		./srcs/parsing/parse_utils.c \
-		./srcs/parsing/parsing_get_color_and_texture.c
+		./srcs/parsing/parsing_get_color_and_texture.c \
+		./srcs/parsing/texture_check.c \
+		./srcs/parsing/rgb_road.c
 OBJS = $(patsubst %.c, %.o, $(SRCS))
 INCDIRS = ./includes
 CFLAGS = -Wall -Wextra -Werror -I$(INCDIRS) -I$(MLX)/include -g3

--- a/includes/parsing.h
+++ b/includes/parsing.h
@@ -25,4 +25,10 @@ void	colors_harvester(t_map *map);
 void	filename_check(char *filename);
 void	skip_spaces(char **str);
 
+// dans texture_check.c
+void	check_textures(t_map *map);
+
+// dans color_
+void	setup_colors(t_data *c3d);
+
 #endif

--- a/includes/types.h
+++ b/includes/types.h
@@ -1,3 +1,14 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   types.h                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: wkeiser <wkeiser@student.42mulhouse.fr>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/11 22:29:40 by wkeiser           #+#    #+#             */
+/*   Updated: 2024/08/11 22:29:45 by wkeiser          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
 
 #ifndef TYPES_H
 # define TYPES_H
@@ -24,6 +35,8 @@ typedef struct s_img
 typedef struct s_data
 {
 	t_map	*map;
+	int		floorcolor;
+	int		ceilingcolor;
 }				t_data;
 
 #endif

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -33,13 +33,12 @@ int	main(int argc, char **argv)
 	if (!c3d->map)
 		exit_exclaim("c3d->map malloc failed\n");
 	parsing(c3d->map, argv, argc, c3d);
-	// check avec des test maps / semble etre good verif en cours encore 
 	printf("North path :%s\n", c3d->map->n_path);
 	printf("S path :%s\n", c3d->map->s_path);
 	printf("W path :%s\n", c3d->map->w_path);
 	printf("E path :%s\n", c3d->map->e_path);
-	printf("Color line ceiling :%s\n", c3d->map->ccolor);
-	printf("Color line floor :%s\n", c3d->map->fcolor);
-	// A venir : poursuite parsing check textures 
+	printf("Converted ceiling color: 0x%X\n", c3d->floorcolor); //testing hexa conversion color
+	printf("Converted floor color: 0x%X\n", c3d->ceilingcolor); //testing hexa conversion color
+
 	return (0);
 }

--- a/srcs/parsing/parsing.c
+++ b/srcs/parsing/parsing.c
@@ -22,4 +22,7 @@ void	parsing(t_map *map, char **filename, int argc, t_data *c3d)
 	if (map->fd == -1)
 		exit_exclaim("Error when openning file\n");
 	colors_harvester(map);
+	check_textures(map);
+	setup_colors(c3d);
+
 }

--- a/srcs/parsing/parsing_get_color_and_texture.c
+++ b/srcs/parsing/parsing_get_color_and_texture.c
@@ -67,7 +67,7 @@ int	add_info(char erase_me, t_map *map, char *palette_patrol, char *line)
 	skip_spaces(&line);
 	if (*line == '\0' || *line == '\n')
 		exit_exclaim("Have you missed something ? Nothing comes \
-							after identifier\n");
+after identifier\n");
 	if (erase_me == 'N')
 		map->n_path = ft_strdup(line);
 	else if (erase_me == 'S')

--- a/srcs/parsing/rgb_road.c
+++ b/srcs/parsing/rgb_road.c
@@ -1,0 +1,93 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   rgb_road.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: wkeiser <wkeiser@student.42mulhouse.fr>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/11 23:48:04 by wkeiser           #+#    #+#             */
+/*   Updated: 2024/08/11 23:48:05 by wkeiser          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../includes/cub3d.h"
+
+void	check_space_in_str_color(char *arr)
+{
+	int	i;
+
+	i = 0;
+	while (arr[i])
+	{
+		if (arr[i] == ' ')
+			exit_exclaim("Found weird spaces in the string colors ! Why ?\n");
+		i++;
+	}
+}
+
+int	parse_rgb_component(char **str)
+{
+	int	value;
+
+	value = ft_atoi(*str);
+	while (**str && **str != ',')
+		(*str)++;
+	if (**str == ',')
+		(*str)++;
+
+	return (value);
+}
+
+
+/* validate fct pour verif si la string donnee comprend bien 2
+virgules et qu apres la 2 eme virgule il y a une valeur*/
+int	validate_rgb_format(char *str)
+{
+	int	count_comma;
+	int	count_length;
+	int	len;
+
+	len = ft_strlen(str);
+	count_comma = 0;
+	count_length = 0;
+	while (*str)
+	{
+		if (*str == ',' && (count_length + 1 != len))
+			count_comma++;
+		str++;
+		count_length++;
+	}
+	return (count_comma == 2);
+}
+
+int	convert_rgb_str_to_int(char *rgb_str)
+{
+	int	r;
+	int	g;
+	int	b;
+
+	r = parse_rgb_component(&rgb_str);
+	g = parse_rgb_component(&rgb_str);
+	b = parse_rgb_component(&rgb_str);
+	if ((r < 0 || r > 255) || (g < 0 || g > 255) || (b < 0 || b > 255))
+		exit_exclaim("Color value out of range\n");
+	printf("R: %d, G: %d, B: %d\n", r, g, b); // test avant conversion
+	return ((r << 16) | (g << 8) | b);
+}
+
+void	setup_colors(t_data *c3d)
+{
+	printf("before convert Color str ceiling :%s\n", c3d->map->ccolor);
+	printf("before convert Color str floor :%s\n", c3d->map->fcolor);
+	check_space_in_str_color(c3d->map->ccolor);
+	check_space_in_str_color(c3d->map->fcolor);
+	if (validate_rgb_format(c3d->map->ccolor) && \
+		validate_rgb_format(c3d->map->fcolor))
+	{
+		c3d->floorcolor = convert_rgb_str_to_int(c3d->map->ccolor);
+		c3d->ceilingcolor = convert_rgb_str_to_int(c3d->map->fcolor);
+	}
+	else
+		exit_exclaim("Check your colors man\n");
+	return ;
+}

--- a/srcs/parsing/texture_check.c
+++ b/srcs/parsing/texture_check.c
@@ -1,0 +1,46 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   texture_check.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: wkeiser <wkeiser@student.42mulhouse.fr>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/11 22:29:28 by wkeiser           #+#    #+#             */
+/*   Updated: 2024/08/11 22:29:29 by wkeiser          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../includes/cub3d.h"
+
+void	filename_texture_check(char *filename)
+{
+	size_t	len;
+
+	len = ft_strlen(filename);
+	if (len < 5)
+		exit_exclaim("How your texture can be that short?\n");
+	if (ft_strcmp(filename + len - 4, ".xpm") != 0)
+		exit_exclaim("Wrong texture file extension\n");
+}
+
+void	check_texture(char *arr)
+{
+	int	i;
+
+	i = 0;
+	while (arr[i])
+	{
+		if (arr[i] == ' ')
+			exit_exclaim("Found weird spaces in texture paths ! Why ?\n");
+		i++;
+	}
+	filename_texture_check(arr);
+}
+
+void	check_textures(t_map *map)
+{
+	check_texture(map->s_path);
+	check_texture(map->w_path);
+	check_texture(map->e_path);
+	check_texture(map->n_path);
+}


### PR DESCRIPTION
Ajout de 2 int dans la structure c3d pour contenir l hexa converti des couleurs contenues dans 2 str initialement,

rajout de printf pour test encore les couleurs, a vérifier si c'est good mais tant dans le path que les couleurs, si il y a un space dans le path ou après et pareil pour les couleurs je renvoit une erreur : exemple "120, 0,120" ou "12,12,12 " renverra une erreur, ce qui oblige le createur de la carte a pas mettre d espace en fin de ligne.

j ai crée une fonction qui check qu il y a bien 2 virgules et 3 valeurs chacune contenue entre 0 et 255

j'ai aussi check l extension du fichier image qui pourra être que .xpm / je ne check pas si l image existe par contre encore